### PR TITLE
Quick fix to get GetFollowers, user_follow and user_unfollow working

### DIFF
--- a/instauto/api/actions/friendships.py
+++ b/instauto/api/actions/friendships.py
@@ -69,7 +69,7 @@ class FriendshipsMixin:
             data = obj.fill(self)
         else:
             data = obj
-        if obj['max_id'] is None and data['page'] > 0:
+        if data['max_id'] is None and data['page'] > 0:
             return obj, False
         query_params = {
             'search_surface': data['search_surface'],

--- a/instauto/api/actions/structs/common.py
+++ b/instauto/api/actions/structs/common.py
@@ -12,8 +12,8 @@ class Base:
     _datapoint_from_client: Dict[str, Tuple[bool, Callable[[], str]]] = {
         "_csrftoken": (False, lambda client: client._session.cookies['csrftoken']),
         "device_id": (False, lambda client: client.state.device_id),
-        "_uuid": (False, lambda client: client.state.uuid),
-        "_uid": (False, lambda client: client.state.user_id)
+        "uuid": (False, lambda client: client.state.uuid),
+        "uid": (False, lambda client: client.state.user_id)
     }
 
     def __init__(self, **kwargs):
@@ -23,7 +23,7 @@ class Base:
         self._kwargs = kwargs
 
     def _enable_datapoint_from_client(self, key: str) -> None:
-        self._datapoint_from_client[key][0] = True
+        self._datapoint_from_client[key] = (True, self._datapoint_from_client[key][1])
 
     def _add_datapoint_from_client(self, key: str, f: Optional[Callable[[], str]], enabled: bool = False):
         self._datapoint_from_client[key] = (enabled, f)

--- a/instauto/api/actions/structs/friendships.py
+++ b/instauto/api/actions/structs/friendships.py
@@ -44,7 +44,6 @@ class Destroy(_Base):
         self._data['endpoint'] = 'destroy'
         self._data['user_id'] = user_id
         self._data['surface'] = surface
-        self._defaults['surface'] = surface.profile
 
 
 class Remove(_Base):
@@ -120,5 +119,4 @@ class ApproveRequest(cmmn.Base):
 
         self._data['user_id'] = user_id
 
-        self._defaults['surface'] = Surface.follow_requests
         self._defaults['radio_type'] = 'wifi-none'

--- a/instauto/api/actions/structs/friendships.py
+++ b/instauto/api/actions/structs/friendships.py
@@ -20,8 +20,8 @@ class _Base(cmmn.Base):
         super().__init__(**kwargs)
         self._enable_datapoint_from_client('_csrftoken')
         self._enable_datapoint_from_client('device_id')
-        self._enable_datapoint_from_client('_uid')
-        self._enable_datapoint_from_client('_uuid')
+        self._enable_datapoint_from_client('uid')
+        self._enable_datapoint_from_client('uuid')
 
         self._custom_data['uuid'] = self.State.required
         self._custom_data['user_id'] = self.State.required


### PR DESCRIPTION
**In GetFollowers**
The original problem was that "obj" didn't have the attribute "max_id".
After reviewing, data was the one with "max_id" attribute


**In user_follow**
The original problem was:
File "/home/ec2-user/Instabot2/instauto_interface.py", line 67, in follow_user
f = fs.Create(user_id=user_id)
File "/home/ec2-user/instauto/instauto/api/actions/structs/friendships.py", line 35, in init
super().init(**kwargs)
File "/home/ec2-user/instauto/instauto/api/actions/structs/friendships.py", line 21, in init
self._enable_datapoint_from_client('_csrftoken')
File "/home/ec2-user/instauto/instauto/api/actions/structs/common.py", line 26, in _enable_datapoint_from_client
self._datapoint_from_client[key][0] = True
TypeError: 'tuple' object does not support item assignment

And then the second problem was that "_uuid" was not found.
That explains the changes.


**In user_unfollow**
The original problem was that "surface" was None so surface.profile threw an exception.
The fix was to remove self._defaults['surface'] = surface.profile because self._defaults['surface'] was unused.