### PR TITLE
Update post.py

### DIFF
--- a/instauto/api/actions/post.py
+++ b/instauto/api/actions/post.py
@@ -145,7 +145,8 @@ class PostMixin:
         if obj.page > 0 and obj.max_id is None:
             return obj, False
 
-        as_dict.pop('max_id')
+        if obj.max_id is not None:
+            as_dict.pop('max_id'
         as_dict.pop('user_id')
 
         resp = self._request(f'feed/user/{obj.user_id}/', Method.GET, query=as_dict)

--- a/instauto/api/actions/post.py
+++ b/instauto/api/actions/post.py
@@ -146,7 +146,7 @@ class PostMixin:
             return obj, False
 
         if obj.max_id is not None:
-            as_dict.pop('max_id'
+            as_dict.pop('max_id')
         as_dict.pop('user_id')
 
         resp = self._request(f'feed/user/{obj.user_id}/', Method.GET, query=as_dict)


### PR DESCRIPTION
**Bug**

![image](https://user-images.githubusercontent.com/64809910/96093785-dedbdc00-0ecc-11eb-9822-ebfabc2cf1fc.png)

**Explanation**
The function to_dict dont add variables to the dict whose values are None.
In case *max_id* is None it will not added to the dict and therefore it cant be popped with *.pop('max_dict')*

![image](https://user-images.githubusercontent.com/64809910/96094267-73463e80-0ecd-11eb-9409-a2fef191eebe.png)

**Solution**
My solution fixes the issue in "post_retrieve_by_user", but maybe same problems exist in other functions.
Maybe it would be better if also object variables with value *None* are added to the dict with *to_dict()*, but I dont know the package well enough to decide this.
