### PR TITLE
Fix code example in Usage section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from instauto.api.client import ApiClient
 from instauto.api.actions import post as ps
 
 if __name__ == '__main__':
-  client = ApiClient("your_username", "your_password")
+  client = ApiClient(username="your_username", password="your_password")
   client.log_in()
 
   like = ps.Like(


### PR DESCRIPTION
While doing #169 I found that example in Usage section in readme is incorrect. The first and second position arguments are not username and password and current example is not working. 

For successful run needs to set username and password as keyword arguments.